### PR TITLE
Cherry-pick changes from kaavee315/gocql

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -19,8 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql/internal/lru"
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/scaledata/gocql/internal/lru"
+	"github.com/scaledata/gocql/internal/streams"
 )
 
 var (

--- a/conn_test.go
+++ b/conn_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/scaledata/gocql/internal/streams"
 )
 
 const (

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/scaledata/gocql/internal/ccm"
 )
 
 func TestEventDiscovery(t *testing.T) {

--- a/host_source_gen.go
+++ b/host_source_gen.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gocql/gocql"
+	"github.com/scaledata/gocql"
 )
 
 func gen(clause, field string) {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,8 +1,9 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/lru"
 	"sync"
+
+	"github.com/scaledata/gocql/internal/lru"
 )
 
 const defaultMaxPreparedStmts = 1000

--- a/session_test.go
+++ b/session_test.go
@@ -168,6 +168,25 @@ func TestQueryShouldPrepare(t *testing.T) {
 			t.Fatalf("expected Query.shouldPrepare to return false, got true for statement '%v'", cantPrepare[i])
 		}
 	}
+
+	toPrepare = []string{"select * ", "INSERT INTO", "update table", "delete from", "begin batch"}
+	cantPrepare = []string{"create table", "USE table", "LIST keyspaces", "alter table", "drop table", "grant user", "revoke user"}
+
+	for i := 0; i < len(toPrepare); i++ {
+		q.stmt = toPrepare[i]
+		q.skipPrepareStmt = true
+		if q.shouldPrepare() {
+			t.Fatalf("expected Query.shouldPrepare to return true, got false for statement '%v'", toPrepare[i])
+		}
+	}
+
+	for i := 0; i < len(cantPrepare); i++ {
+		q.stmt = cantPrepare[i]
+		q.skipPrepareStmt = true
+		if q.shouldPrepare() {
+			t.Fatalf("expected Query.shouldPrepare to return false, got true for statement '%v'", cantPrepare[i])
+		}
+	}
 }
 
 func TestBatchBasicAPI(t *testing.T) {

--- a/token.go
+++ b/token.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gocql/gocql/internal/murmur"
+	"github.com/scaledata/gocql/internal/murmur"
 )
 
 // a token partitioner


### PR DESCRIPTION
Cherry-pick changes from kaavee315/gocql.  This include the changes that were done to make non-prepare statements work with gocql. This commit also changes the imports to use scaledata gocql instead of gocql/gocql