### PR TITLE
Fix canonical import in doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,6 @@
 
 // Package gocql implements a fast and robust Cassandra driver for the
 // Go programming language.
-package gocql // import "github.com/gocql/gocql"
+package gocql // import "github.com/scaledata/gocql"
 
 // TODO(tux21b): write more docs.


### PR DESCRIPTION
If any file is importing this package as "github.com/scaledata/gocql", go build fails with error
```
(.buildenv) dhawal-upadhyay-m:spark dhawalupadhyay$ go build ~/work/sdmain/src/go/src/rubrik/sqload/cmd/sqload/main.go
../sdmain/src/go/src/rubrik/sqload/cassandra_query_executor.go:4:2: code in directory /Users/dhawalupadhyay/work/sdmain/src/go/src/rubrik/vendor/github.com/scaledata/gocql expects import "github.com/gocql/gocql"
```
This happens because the [canonical import](https://golang.org/doc/go1.4#canonicalimports) in doc.go expects this package to be imported as "github.com/gocql/gocql". 

This also causes error when running go test.

I'm seeing this error with Go version `go1.14.2 darwin/amd64` which is on Polaris. Although it works fine inside CDM's sd_dev_box which has Go version `go1.10.1 linux/amd64` installed. We should still fix it because it'll break whenever we move to newer Go version in sdmain.