### PR TITLE
Perform null check before dereference

### DIFF
--- a/control.go
+++ b/control.go
@@ -386,7 +386,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 	}
 
 	oldConn := c.getConn()
-	if oldConn.conn != conn {
+	if oldConn != nil && oldConn.conn != conn {
 		return
 	}
 


### PR DESCRIPTION
This code path gets when when we try to handleError while closing go cql connection closeWithError which internally calls HandleError.