### PR TITLE
Bound hostConnPool.Pick() when the pool is empty

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -349,13 +349,22 @@ func (pool *hostConnPool) Pick() *Conn {
 	}
 
 	size := len(pool.conns)
-	for size == 0 {
+	if size == 0 {
 		pool.mu.RUnlock()
-		// fill one connection synchronously
+		// Make a single synchronous attempt to fill one connection. We must
+		// not loop here: if the host is unreachable, fill() can never succeed
+		// and a loop would spin forever below the query layer, where no query
+		// timeout or retry limit can interrupt it. Returning nil instead lets
+		// the caller (query executor) move to the next host and rely on its
+		// retry/timeout logic, while the background fill() kicked off below
+		// repopulates the pool for subsequent picks.
 		pool.fill()
 		pool.mu.RLock()
 		// Re-read size after filling
 		size = len(pool.conns)
+		if size == 0 {
+			return nil
+		}
 	}
 	if size < pool.size {
 		// try to fill the pool

--- a/connectionpool_test.go
+++ b/connectionpool_test.go
@@ -1539,3 +1539,101 @@ func TestConnectionTracking_WithExpiration(t *testing.T) {
 		)
 	}
 }
+
+// TestPick_UnreachableHostDoesNotHang is a regression test for the unbounded
+// loop that previously lived in Pick(). When the pool is empty and the host is
+// unreachable, fill() can never succeed; the old code looped on fill()
+// forever, hanging below the query layer where no query timeout or retry limit
+// could interrupt it (observed as 60-minute TestCyclopsFuzzy timeouts).
+//
+// The fixed Pick() makes a single synchronous fill attempt and then returns
+// nil, letting the caller's retry/timeout logic take over.
+func TestPick_UnreachableHostDoesNotHang(t *testing.T) {
+	session := createTestSession()
+	host := &HostInfo{
+		connectAddress: net.IPv4(127, 0, 0, 1),
+		port:           9042,
+	}
+
+	pool := &hostConnPool{
+		session:            session,
+		host:               host,
+		port:               9042,
+		addr:               "127.0.0.1:9042",
+		size:               3,
+		keyspace:           "",
+		conns:              make([]*Conn, 0, 3),
+		expiredConns:       make([]*Conn, 0, maxDrainingConns),
+		filling:            false,
+		closed:             false,
+		maintenanceStarted: false,
+		maintenanceTicker:  100 * time.Millisecond,
+		// Simulate an unreachable host: every connection attempt fails, so the
+		// pool can never be filled.
+		connFactory: func() (*Conn, error) {
+			return nil, fmt.Errorf("simulated unreachable host")
+		},
+	}
+
+	// Run Pick() in a goroutine so the test itself cannot hang: if Pick()
+	// regresses to the unbounded loop, the select below fails fast instead of
+	// blocking the whole test binary until the go test timeout.
+	done := make(chan *Conn, 1)
+	go func() {
+		done <- pool.Pick()
+	}()
+
+	select {
+	case conn := <-done:
+		if conn != nil {
+			t.Fatalf("expected Pick() to return nil for an unreachable host, got %p", conn)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Pick() hung on an unreachable host (regression: unbounded fill loop)")
+	}
+}
+
+// TestPick_EmptyPoolFillsSynchronously verifies that the single synchronous
+// fill attempt is preserved: when the pool starts empty but the host is
+// reachable, the first Pick() establishes a connection and returns it rather
+// than returning nil.
+func TestPick_EmptyPoolFillsSynchronously(t *testing.T) {
+	session := createTestSession()
+	host := &HostInfo{
+		connectAddress: net.IPv4(127, 0, 0, 1),
+		port:           9042,
+	}
+
+	pool := &hostConnPool{
+		session:            session,
+		host:               host,
+		port:               9042,
+		addr:               "127.0.0.1:9042",
+		size:               3,
+		keyspace:           "",
+		conns:              make([]*Conn, 0, 3),
+		expiredConns:       make([]*Conn, 0, maxDrainingConns),
+		filling:            false,
+		closed:             false,
+		maintenanceStarted: false,
+		maintenanceTicker:  100 * time.Millisecond,
+		// Reachable host: each attempt yields a fresh, non-expiring connection.
+		connFactory: func() (*Conn, error) {
+			return fakeConn(3, time.Now(), 0), nil
+		},
+	}
+
+	done := make(chan *Conn, 1)
+	go func() {
+		done <- pool.Pick()
+	}()
+
+	select {
+	case conn := <-done:
+		if conn == nil {
+			t.Fatal("expected Pick() to synchronously fill and return a connection")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Pick() did not return within the timeout")
+	}
+}


### PR DESCRIPTION
## Summary

`hostConnPool.Pick()` previously looped on `fill()` forever when the pool was empty and the host was unreachable. Because this loop runs below the query layer, no query timeout or retry limit could interrupt it, so an operation against an unreachable host would hang indefinitely. This surfaced downstream as 60-minute `TestCyclopsFuzzy` (`TestCqlproxyCyclopsWithTCPProxy`) timeouts under the fault-injecting TCP proxy: the proxy intermittently drops/refuses connections, the pool empties, and `Pick()` spins refilling forever.

The unbounded-loop behavior was introduced in PR #9 (`Implement maxConnLifetime`), which changed `Pick()` from returning `nil` on an empty pool to looping until a connection appears. The same PR also added periodic connection recycling, which makes the empty-pool state occur more often.

## Fix

Replace the unbounded `for size == 0` loop with a single synchronous `fill()` attempt, then `return nil` if the pool is still empty:

- The query executor (`query_executor.go`) already handles a `nil` connection by moving to the next host and relying on its retry/timeout logic.
- The background `go pool.fill()` kicked off later in `Pick()` still repopulates the pool for subsequent picks.
- The single synchronous attempt preserves the first-query latency benefit from #9.
- The fix is independent of `ConnMaxLifetime` — it holds whether or not recycling is enabled.

## Tests

Added two regression tests in `connectionpool_test.go`:

- `TestPick_UnreachableHostDoesNotHang` — with a `connFactory` that always fails, `Pick()` must return `nil` within a bounded time (guarded by a 5s `select`) instead of spinning. This is the direct guard against the hang.
- `TestPick_EmptyPoolFillsSynchronously` — with a reachable host, the first `Pick()` still fills synchronously and returns a connection.

Full unit suite passes:

```
go test -tags unit -c -o /tmp/gocql_unit_test && /tmp/gocql_unit_test
PASS
```
